### PR TITLE
overwrote line to use correct variable pointer

### DIFF
--- a/lib/ruby-sdl-ffi/sdl/mac.rb
+++ b/lib/ruby-sdl-ffi/sdl/mac.rb
@@ -158,7 +158,7 @@ if FFI::Platform.mac? and ($0 != "rsdl") and \
       typedef :pointer, :sel
       typedef :pointer, :ivar
       typedef :pointer, :nsclass
-      callback :imp, [:id, :sel, :varargs], :id
+      callback :imp, [:id, :sel, :ivar], :id
 
 
       class NSObject < NiceFFI::OpaqueStruct


### PR DESCRIPTION
Fix from https://github.com/xrs1133/ruby-sdl-ffi/commit/0b721ac4659b4c08cda5aa2f418561a8a311e85b

Without this, you see stack traces like

```
22:58 $ twitterpunch-dev -s
/Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/ffi-1.9.18/lib/ffi/library.rb:395:in `callback': callbacks cannot have variadic parameters (ArgumentError)
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/ruby-sdl-ffi-0.4/lib/ruby-sdl-ffi/sdl/mac.rb:161:in `<module:ObjC>'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/ruby-sdl-ffi-0.4/lib/ruby-sdl-ffi/sdl/mac.rb:153:in `<module:Mac>'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/ruby-sdl-ffi-0.4/lib/ruby-sdl-ffi/sdl/mac.rb:49:in `<top (required)>'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/ruby-sdl-ffi-0.4/lib/ruby-sdl-ffi/sdl.rb:80:in `block in <top (required)>'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/ruby-sdl-ffi-0.4/lib/ruby-sdl-ffi/sdl.rb:79:in `each'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/ruby-sdl-ffi-0.4/lib/ruby-sdl-ffi/sdl.rb:79:in `<top (required)>'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/rubygame-2.6.4/lib/rubygame/main.rb:22:in `<top (required)>'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/rubygame-2.6.4/lib/rubygame.rb:44:in `block in <top (required)>'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/rubygame-2.6.4/lib/rubygame.rb:43:in `each'
	from /Users/ben/.rvm/gems/ruby-2.3.3@twitterpunch/gems/rubygame-2.6.4/lib/rubygame.rb:43:in `<top (required)>'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `require'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from /Users/ben/Projects/twitterpunch/lib/twitterpunch/viewer.rb:2:in `<top (required)>'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/ben/Projects/twitterpunch/bin/twitterpunch:94:in `<main>'
```